### PR TITLE
Update to Quectel LG69T-AM version 0.17.0 and -AP version 0.14.0.

### DIFF
--- a/p1_runner/main.py
+++ b/p1_runner/main.py
@@ -104,9 +104,9 @@ Forward NMEA output from the receiver to an application on TCP port 1234:
         help="The baud rate used by the corrections serial port (--corrections-port).")
 
     device_group.add_argument(
-        '--reset-type', choices=('hot', 'warm', 'cold', 'none'), default='hot',
+        '--reset-type', choices=('hot', 'warm', 'pvt', 'diag', 'cold', 'none'), default='none',
         help="The type of reset to perform after connecting to the device. Resetting helps to facilitate deterministic "
-             "log playback.")
+             "log playback. When capturing a log for diagnostic and support purposes, use 'diag'.")
 
     device_group.add_argument(
         '--no-reset', action='store_true',
@@ -137,6 +137,9 @@ Forward NMEA output from the receiver to an application on TCP port 1234:
         help="The username and password to use when receiving RTK corrections from Point One the Polaris network. "
              "--ntrip and --ntrip-tls will be ignored if --polaris is specified. If username is omitted, it will be "
              "set to the device ID (--device-id).")
+    corr_sel_group.add_argument(
+        '--polaris-hostname', metavar='HOSTNAME', default='polaris.pointonenav.com',
+        help="The hostname used to access the Point One Polaris network.")
 
     corr_group.add_argument(
         '--polaris-tls', action='store_true', default=True,
@@ -277,7 +280,7 @@ Forward NMEA output from the receiver to an application on TCP port 1234:
             logging.getLogger('ntripstreams').setLevel(logging.DEBUG)
             logging.getLogger('ntripstreams.receive').setLevel(logging.INFO)
         elif options.verbose == 3:
-            logging.root.setLevel(logging.DEBUG)
+            logging.Logger.root.setLevel(logging.DEBUG)
             logging.getLogger('point_one.p1_runner').setLevel(logging.TRACE - 1)
             logging.getLogger('point_one.p1_runner.output').setLevel(logging.TRACE)
             logging.getLogger('point_one.p1_runner.websocket').setLevel(logging.TRACE)
@@ -289,7 +292,7 @@ Forward NMEA output from the receiver to an application on TCP port 1234:
             logging.getLogger('point_one.rtcm_framer').setLevel(logging.DEBUG)
             logging.getLogger('point_one.fusion_engine').setLevel(logging.DEBUG)
         else:
-            logging.root.setLevel(logging.DEBUG)
+            logging.Logger.root.setLevel(logging.DEBUG)
             logging.getLogger('point_one.p1_runner').setLevel(logging.TRACE - 1)
             logging.getLogger('point_one.p1_runner.output').setLevel(logging.TRACE)
             logging.getLogger('point_one.p1_runner.websocket').setLevel(logging.TRACE)
@@ -381,9 +384,9 @@ Forward NMEA output from the receiver to an application on TCP port 1234:
 
     if options.polaris is not None:
         if options.polaris_tls:
-            url = 'https://ntrip.polaris.pointonenav.com:2102'
+            url = f'https://{options.polaris_hostname}:2102'
         else:
-            url = 'http://ntrip.polaris.pointonenav.com:2101'
+            url = f'http://{options.polaris_hostname}:2101'
 
         parts = options.polaris.split(",")
         if len(parts) == 1:

--- a/p1_runner/ntrip_client.py
+++ b/p1_runner/ntrip_client.py
@@ -10,6 +10,7 @@ import traceback
 from urllib3.util import parse_url
 
 import ntripstreams
+from serial import SerialException
 
 from . import trace as logging
 
@@ -171,6 +172,8 @@ class NTRIPClient(threading.Thread):
                 self.data_callback(data)
             asyncio.run_coroutine_threadsafe(self.__receive_data(), loop=self.event_loop)
         except asyncio.CancelledError as e:
+            raise e
+        except SerialException as e:
             raise e
         except asyncio.TimeoutError:
             self.rx_logger.trace('Read timed out with no data. Reading again.', depth=2)

--- a/p1_runner/runner.py
+++ b/p1_runner/runner.py
@@ -316,7 +316,8 @@ class P1Runner(threading.Thread):
                 data = self.device_serial.read(self.device_serial.in_waiting or 1)
             except serial.SerialException as e:
                 self.logger.error('Unexpected error reading from device:\r%s' % traceback.format_exc())
-                break
+                self.logger.error('Application exiting.')
+                sys.exit(1)
 
             if len(data) > 0:
                 self.last_data_timeout_warning_time = None
@@ -472,6 +473,10 @@ Are you using the correct UART/COM port (--device-port)?
             reset_cmd.reset_mask = ResetRequest.HOT_START
         elif self.reset_type == 'warm':
             reset_cmd.reset_mask = ResetRequest.WARM_START
+        elif self.reset_type == 'pvt':
+            reset_cmd.reset_mask = ResetRequest.PVT_RESET
+        elif self.reset_type == 'diag':
+            reset_cmd.reset_mask = ResetRequest.DIAGNOSTIC_LOG_RESET
         elif self.reset_type == 'cold':
             reset_cmd.reset_mask = ResetRequest.COLD_START
         else:

--- a/p1_runner/wheel_tick_display.py
+++ b/p1_runner/wheel_tick_display.py
@@ -37,10 +37,10 @@ class WheelTickDisplay:
         # hardware tick config. Once we have both, we'll actually print the result.
         self.device_interface.get_config(ConfigurationSource.ACTIVE, WheelConfig.GetType())
 
-    def handle_message(self, header: MessageHeader, response_payload: WheelTickMeasurement, *args):
-        if header.message_type == MessageType.VEHICLE_TICK_MEASUREMENT:
+    def handle_message(self, header: MessageHeader, response_payload: MessagePayload, *args):
+        if header.message_type == MessageType.RAW_VEHICLE_TICK_OUTPUT:
             self._handle_vehicle_tick_message(response_payload)
-        elif header.message_type == MessageType.VEHICLE_SPEED_MEASUREMENT:
+        elif header.message_type == MessageType.VEHICLE_SPEED_OUTPUT:
             self._handle_vehicle_speed_message(response_payload)
         elif header.message_type == MessageType.POSE:
             self._handle_pose_message(response_payload)
@@ -63,7 +63,7 @@ class WheelTickDisplay:
             self.logger.info(self.wheel_config)
             self.logger.info("############################## END CONFIGURATION ###############################")
 
-    def _handle_vehicle_tick_message(self, message: WheelTickMeasurement):
+    def _handle_vehicle_tick_message(self, message: RawVehicleTickOutput):
         # If we never got a speed message corresponding with the previous tick message, print the old tick data now.
         # Otherwise, we'll print when the speed message comes in.
         if self.tick_count is not None:
@@ -75,7 +75,7 @@ class WheelTickDisplay:
 
         self.last_data_p1_time = self.p1_time
 
-    def _handle_vehicle_speed_message(self, message: VehicleSpeedMeasurement):
+    def _handle_vehicle_speed_message(self, message: VehicleSpeedOutput):
         p1_time = message.get_p1_time()
 
         # Check if we have pending tick data that corresponds with this speed message.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 argparse-formatter>=1.4
 colorama>=0.4.4
 construct~=2.10.67
-fusion-engine-client==1.17.0
+fusion-engine-client==1.18.0
 gpstime>=0.6.2
 pynmea2~=1.18.0
 pyserial~=3.5

--- a/setup.py
+++ b/setup.py
@@ -5,13 +5,13 @@ here = pathlib.Path(__file__).parent.resolve()
 
 setup(
     name='p1-host-tools',
-    version='v0.16.1',
+    version='v0.17.0',
     packages=find_packages(where='.'),
     install_requires=[
         "argparse-formatter>=1.4",
         "colorama>=0.4.4",
         "construct~=2.10.67",
-        "fusion-engine-client==1.17.0",
+        "fusion-engine-client==1.18.0",
         "gpstime>=0.6.2",
         "psutil>=5.9.4",
         "pynmea2~=1.18.0",


### PR DESCRIPTION
New Features
- [lg69t] Added diagnostic logging of user commands/responses
- [lg69t] Added runtime leap second and GPS week rollover transition and manual
  override user config support (P1-12, P1-99)
- [lg69t] Added additional info to FusionEngine GNSSInfoMessage (corrections
  age, baseline distance, # SVs, leap second)
- [lg69t] Added new FusionEngine wheel speed input/output message definitions
  - Previous WheelSpeedMeasurement and VehicleSpeedMeasurement messages no
    longer supported
- [lg69t] Added new FusionEngine raw (uncorrected) IMU and wheel speed/tick
  output message definitions
- [lg69t] Added new InterfaceConfig option to FusionEngine SetConfig message
  - UARTn_* options now deprecated
- [lg69t] Added new FusionEngine SystemStatus message containing GNSS receiver
  temperature
- [lg69t] Report sensor data source in IMU/wheel speed measurement output
- [lg69t, config_tool] Added option to revert user config settings back to
  default values

Changes
- [lg69t, config_tool] Updated to FusionEngine protocol version 1.18.0
- [lg69t] Changed definition of user cold/warm/hot start and added new PVT_RESET
  and DIAGNOSTIC_LOG_RESET options (P1-109)
- [lg69t] Updated blackout region definition (P1-97)
- [lg69t] Enable output of corrected IMU and wheel speed before the navigation
  engine initializes
- [lg69t-am/ap] Improved RTK fixing performance while stationary (P1-46)
- [lg69t-ah] Enable heading calculation using primary device without RTK
  corrections
- [lg69t-ah] Improved performance in high multipath environments
- [teseo] Updated Teseo firmware 5.8.20.0-20230317 to lower tracking and
  navigation C/N0 thresholds (P1-108)

Fixes
- [lg69t] Fixed possible output hang or early entrance/exit from region
  blackout caused by disabled PPS (P1-97, P1-112, P1-113)
- [lg69t] Resolved unexpectedly dropped GNSS measurements caused by larger than
  expected Teseo output latency (P1-111, P1-115)
- [lg69t] Fixed memory leak if RTCM 1033 message is present in corrections
  stream
- [lg69t] Fixed "active differs from saved" check for wheel speed configuration
  settings
- [p1_runner] Fixed flood of NTRIP reconnect requests if device is unplugged
  from USB