### PR TITLE
Fixed `p1_runner` TCP output client disconnect handling.

### DIFF
--- a/p1_runner/output_server.py
+++ b/p1_runner/output_server.py
@@ -203,9 +203,13 @@ class OutputServer(object):
                         'Unexpected error from TCP socket:\r%s' % traceback.format_exc())
                 break
 
-            data = client.recv(1024)
-            if data and self.incoming_data_callback is not None:
-                self.incoming_data_callback(data)
+            try:
+                data = client.recv(1024)
+                if data and self.incoming_data_callback is not None:
+                    self.incoming_data_callback(data)
+            except (BrokenPipeError, ConnectionResetError):
+                self.logger.error('Connection reset by peer.')
+                continue
 
         self.logger.debug('TCP thread finished.')
 

--- a/p1_runner/output_server.py
+++ b/p1_runner/output_server.py
@@ -208,7 +208,7 @@ class OutputServer(object):
                 if data and self.incoming_data_callback is not None:
                     self.incoming_data_callback(data)
             except (BrokenPipeError, ConnectionResetError):
-                self.logger.error('Connection reset by peer.')
+                self.logger.error('Reconnecting tcp://'+str(addr[0])+':'+str(addr[1]))
                 continue
 
         self.logger.debug('TCP thread finished.')

--- a/p1_runner/output_server.py
+++ b/p1_runner/output_server.py
@@ -208,7 +208,7 @@ class OutputServer(object):
                 if data and self.incoming_data_callback is not None:
                     self.incoming_data_callback(data)
             except (BrokenPipeError, ConnectionResetError):
-                self.logger.error('Reconnecting tcp://'+str(addr[0])+':'+str(addr[1]))
+                self.logger.info('Output client tcp://%s:%d disconnected.' % (addr[0], addr[1]))
                 continue
 
         self.logger.debug('TCP thread finished.')


### PR DESCRIPTION
# Fixes
- Fixed broken pipe and connection reset handling for TCP clients in `p1_runner`