### PR TITLE
Update log_manager timestamping

### DIFF
--- a/bin/config_message_rate.py
+++ b/bin/config_message_rate.py
@@ -50,10 +50,12 @@ MESSAGE_RATE_MAP = {
     '500ms': MessageRate.INTERVAL_500_MS,
     '200ms': MessageRate.INTERVAL_200_MS,
     '100ms': MessageRate.INTERVAL_100_MS,
+    '10ms': MessageRate.INTERVAL_10_MS,
     '1hz': MessageRate.INTERVAL_1_S,
     '2hz': MessageRate.INTERVAL_500_MS,
     '5hz': MessageRate.INTERVAL_200_MS,
     '10hz': MessageRate.INTERVAL_100_MS,
+    '100hz': MessageRate.INTERVAL_10_MS,
     'default': MessageRate.DEFAULT,
 }
 

--- a/p1_runner/main.py
+++ b/p1_runner/main.py
@@ -5,6 +5,7 @@ import sys
 import threading
 
 from fusion_engine_client.utils.log import DEFAULT_LOG_BASE_DIR
+from fusion_engine_client.utils.socket_timestamping import TIMESTAMP_FILE_ENDING
 from urllib3.util import parse_url
 
 from . import trace as logging
@@ -234,7 +235,8 @@ Forward NMEA output from the receiver to an application on TCP port 1234:
 
     logging_group.add_argument(
         '--log-timestamps', action='store_true',
-        help="Generate an \"input.timestamps\" file with a mapping of the run time to a byte offsets in the data log.")
+        help=f'Generate an "input.raw{TIMESTAMP_FILE_ENDING}" file with a mapping of the run time to a byte offsets in '
+              'the data log.')
 
     ref_group = parser.add_argument_group('Reference FusionEngine Device')
     ref_group.add_argument(

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ argparse-formatter>=1.4
 colorama>=0.4.4
 construct~=2.10.67
 deepdiff>=8.0.1
-fusion-engine-client==1.24.1
+fusion-engine-client==1.24.2rc1
 pynmea2~=1.18.0
 pyserial~=3.5
 urllib3>=1.21.1

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ requirements = [
     "colorama>=0.4.4",
     "construct~=2.10.67",
     "deepdiff>=8.0.1",
-    "fusion-engine-client==1.24.1",
+    "fusion-engine-client==1.24.2rc1",
     "psutil>=5.9.4",
     "pynmea2~=1.18.0",
     "pyserial~=3.5",


### PR DESCRIPTION
# Changes
 - Make the LogManager time stamping compatible to with fusion-engine-client implementation
 - Add socket kernel timestamping
 - Avoid single byte reads in the DeviceInterface
 - Add 100hz message rate option

