### PR TITLE
Fixed `config_tool` interface config issues.

### DIFF
--- a/bin/config_message_rate.py
+++ b/bin/config_message_rate.py
@@ -23,9 +23,13 @@ INTERFACE_MAP = {
     'tcp1': InterfaceID(TransportType.TCP, 1),
     'tcp2': InterfaceID(TransportType.TCP, 2),
     'tcp3': InterfaceID(TransportType.TCP, 3),
-    'file': InterfaceID(TransportType.FILE, 1),
+    'tcp4': InterfaceID(TransportType.TCP, 4),
+    'tcp5': InterfaceID(TransportType.TCP, 5),
+    'file1': InterfaceID(TransportType.FILE, 1),
+    'file2': InterfaceID(TransportType.FILE, 2),
     'unix1': InterfaceID(TransportType.UNIX, 1),
     'unix2': InterfaceID(TransportType.UNIX, 2),
+    'ws1': InterfaceID(TransportType.WEBSOCKET, 1),
 }
 
 PROTOCOL_MAP = {

--- a/bin/config_tool.py
+++ b/bin/config_tool.py
@@ -767,10 +767,15 @@ def request_shutdown(config_interface: DeviceInterface, args):
 
 
 def request_startup(config_interface: DeviceInterface, args):
-    flags = {
+    flag_by_type = {
         'engine': StartupRequest.START_ENGINE,
         'log': StartupRequest.START_NEW_LOG,
-    }[args.type]
+    }
+
+    flags = flag_by_type[args.type]
+    if args.type == 'engine' and args.log_at_startup:
+        flags |= StartupRequest.START_NEW_LOG
+
     config_interface.send_message(StartupRequest(flags))
 
     resp = config_interface.wait_for_message(CommandResponseMessage.MESSAGE_TYPE)
@@ -1822,10 +1827,13 @@ The type of shutdown to be performed: {''.join([f'{newline}- {k} - {v}' for k, v
         help=help,
         description=help)
     choices = {
-        'engine': 'Startup the engine',
+        'engine': 'Start the navigation engine',
         'log': 'Start a new log',
     }
     newline = '\n'
+    startup_parser.add_argument(
+        '-l', '--log-at-startup', action=ExtendedBooleanAction,
+        help="If set, start logging when the navigation engine is started. Applies to `engine` only.")
     startup_parser.add_argument(
         'type', metavar='TYPE',
         choices=choices.keys(),

--- a/bin/config_tool.py
+++ b/bin/config_tool.py
@@ -397,7 +397,7 @@ INTERFACE_PARAM_DEFINITION = {
     'remote_address': {'format': InterfaceRemoteAddressConfig, 'arg_parse': _args_to_address},
     'enabled': {'format': InterfaceEnabledConfig, 'arg_parse': _args_to_bool},
     'direction': {'format': InterfaceDirectionConfig, 'arg_parse': _str_to_transport_direction},
-    'socket_type': {'format': InterfaceDirectionConfig, 'arg_parse': _str_to_socket_type},
+    'socket_type': {'format': InterfaceSocketTypeConfig, 'arg_parse': _str_to_socket_type},
     'diagnostics_enabled': {'format': InterfaceDiagnosticMessagesEnabled, 'arg_parse': _args_to_bool},
     'message_rate': {'format': list, 'arg_parse': message_rate_args_to_output_interface},
 }
@@ -1577,6 +1577,26 @@ NMEA message types:
             baud_rate_parser.add_argument('baud_rate', type=int,
                                           help='The desired baud rate (in bits/second).')
 
+        if interface_id.type in (TransportType.TCP, TransportType.UNIX, TransportType.CURRENT):
+            # config_tool.py apply INTERFACE_NAME direction
+            help = 'Configure the interface direction (client or server).'
+            read_interface_config_type_parsers.add_parser(
+                'direction', help=help, description=help)
+            baud_rate_parser = apply_interface_config_type_parsers.add_parser(
+                'direction', help=help, description=help)
+            baud_rate_parser.add_argument('direction', choices=_transport_direction_map.keys(),
+                                          help='The desired interface direction.')
+
+        if interface_id.type in (TransportType.UNIX, TransportType.CURRENT):
+            # config_tool.py apply INTERFACE_NAME socket_type
+            help = 'Configure the UNIX domain socket type.'
+            read_interface_config_type_parsers.add_parser(
+                'socket_type', help=help, description=help)
+            baud_rate_parser = apply_interface_config_type_parsers.add_parser(
+                'socket_type', help=help, description=help)
+            baud_rate_parser.add_argument('direction', choices=_socket_type_map.keys(),
+                                          help='The desired socket type.')
+
         if interface_id.type in (TransportType.UDP, TransportType.TCP, TransportType.WEBSOCKET, TransportType.CURRENT):
             # config_tool.py apply INTERFACE_NAME port
             help = 'Configure the network port.'
@@ -1589,7 +1609,7 @@ NMEA message types:
 
         if interface_id.type in (TransportType.UDP, TransportType.TCP, TransportType.UNIX, TransportType.CURRENT):
             # config_tool.py apply INTERFACE_NAME remote_address
-            help = 'Configure the remote hostname or IP address, or the socket file path for UNIX domain sockets.'
+            help = 'Configure the remote hostname or IP address (UDP or TCP client), or the socket file path for UNIX domain sockets.'
             read_interface_config_type_parsers.add_parser('remote_address', help=help, description=help)
             baud_rate_parser = apply_interface_config_type_parsers.add_parser('remote_address', help=help,
                                                                               description=help)

--- a/bin/config_tool.py
+++ b/bin/config_tool.py
@@ -132,7 +132,7 @@ def _args_to_vehicle_details(cls, args, config_interface):
     resp = config_interface.wait_for_message(ConfigResponseMessage.MESSAGE_TYPE)
 
     if resp is None:
-        raise RuntimeError('Response timed out after %d seconds while querying current values.' % RESPONSE_TIMEOUT)
+        raise RuntimeError('Error querying current setting.')
 
     if args.vehicle_model is None:
         vehicle_model = resp.config_object.vehicle_model
@@ -155,7 +155,7 @@ def _args_to_wheel_config(cls, args, config_interface):
     resp = config_interface.wait_for_message(ConfigResponseMessage.MESSAGE_TYPE)
 
     if resp is None:
-        raise RuntimeError('Response timed out after %d seconds while querying current values.' % RESPONSE_TIMEOUT)
+        raise RuntimeError('Error querying current setting.')
 
     new_values = {}
 
@@ -199,7 +199,7 @@ def _args_to_hardware_tick_config(cls, args, config_interface):
     resp = config_interface.wait_for_message(ConfigResponseMessage.MESSAGE_TYPE)
 
     if resp is None:
-        raise RuntimeError('Response timed out after %d seconds while querying current values.' % RESPONSE_TIMEOUT)
+        raise RuntimeError('Error querying current setting.')
 
     if args.tick_mode is None:
         tick_mode = resp.config_object.tick_mode
@@ -233,7 +233,6 @@ def _args_to_enabled_gnss_systems(cls, args, config_interface):
         config_interface.get_config(ConfigurationSource.ACTIVE, ConfigType.ENABLED_GNSS_SYSTEMS)
         resp = config_interface.wait_for_message(ConfigResponseMessage.MESSAGE_TYPE)
         if resp is None:
-            logger.error('Read timed out after %d seconds.' % RESPONSE_TIMEOUT)
             return False
         elif resp.response != Response.OK:
             logger.error('Error querying GNSS systems: %s (%d)' % (str(resp.response), int(resp.response)))
@@ -283,7 +282,7 @@ def _args_to_ionosphere_config(cls, args, config_interface):
     resp = config_interface.wait_for_message(ConfigResponseMessage.MESSAGE_TYPE)
 
     if resp is None:
-        raise RuntimeError('Response timed out after %d seconds while querying current values.' % RESPONSE_TIMEOUT)
+        raise RuntimeError('Error querying current setting.')
 
     if args.iono_delay_model is None:
         iono_delay_model = resp.config_object.iono_delay_model
@@ -299,7 +298,7 @@ def _args_to_troposphere_config(cls, args, config_interface):
     resp = config_interface.wait_for_message(ConfigResponseMessage.MESSAGE_TYPE)
 
     if resp is None:
-        raise RuntimeError('Response timed out after %d seconds while querying current values.' % RESPONSE_TIMEOUT)
+        raise RuntimeError('Error querying current setting.')
 
     if args.tropo_delay_model is None:
         tropo_delay_model = resp.config_object.tropo_delay_model
@@ -471,7 +470,6 @@ def read_config(config_interface: DeviceInterface, args):
 
             # Check if the response timed out.
             if not isinstance(resp, ConfigResponseMessage):
-                logger.error('Response timed out after %d seconds.' % RESPONSE_TIMEOUT)
                 return None
 
             # Now print the response.
@@ -539,7 +537,6 @@ def revert_config(config_interface: DeviceInterface, args):
 
             # Check if the response timed out.
             if not isinstance(resp, CommandResponseMessage):
-                logger.error('Response timed out after %d seconds.' % RESPONSE_TIMEOUT)
                 return None
 
             # Now print the response.
@@ -580,7 +577,6 @@ def apply_config(config_interface: DeviceInterface, args):
         config_interface.set_config(config_object, save=args.save, interface=interface_id)
         resp = config_interface.wait_for_message(CommandResponseMessage.MESSAGE_TYPE)
         if not isinstance(resp, CommandResponseMessage):
-            logger.error('Response timed out after %d seconds.' % RESPONSE_TIMEOUT)
             return False
         elif resp.response != Response.OK:
             logger.error('Apply command rejected: %s (%d)' % (str(resp.response), int(resp.response)))
@@ -603,7 +599,6 @@ def save_config(config_interface: DeviceInterface, args):
 
     resp = config_interface.wait_for_message(CommandResponseMessage.MESSAGE_TYPE)
     if not isinstance(resp, CommandResponseMessage):
-        logger.error('Response timed out after %d seconds.' % RESPONSE_TIMEOUT)
         return False
     elif resp.response != Response.OK:
         logger.error('Saving command rejected: %s (%d)' % (str(resp.response), int(resp.response)))
@@ -630,9 +625,7 @@ def query_system_status(config_interface: DeviceInterface, args):
     config_interface.send_message(MessageRequest(MessageType.SYSTEM_STATUS))
 
     resp = config_interface.wait_for_message(MessageType.SYSTEM_STATUS)
-    if resp is None:
-        logger.error('Response timed out after %d seconds.' % RESPONSE_TIMEOUT)
-    else:
+    if resp is not None:
         logger.info(str(resp))
     return resp
 
@@ -642,9 +635,7 @@ def query_device_id(config_interface: DeviceInterface, args):
     config_interface.send_message(MessageRequest(MessageType.DEVICE_ID))
 
     resp = config_interface.wait_for_message(MessageType.DEVICE_ID)
-    if resp is None:
-        logger.error('Response timed out after %d seconds.' % RESPONSE_TIMEOUT)
-    else:
+    if resp is not None:
         logger.info(str(resp))
     return resp
 
@@ -665,7 +656,6 @@ def query_fe_version(config_interface: DeviceInterface, args) -> Optional[Versio
         logger.info(str(resp))
         return resp
     else:
-        logger.error('Response timed out after %d seconds.' % RESPONSE_TIMEOUT)
         return None
 
 
@@ -676,7 +666,6 @@ def query_nmea_versions(config_interface: DeviceInterface, args):
     config_interface.send_message('$PQTMVERNO')
     resp = config_interface.wait_for_message('$PQTMVERNO')
     if resp is None:
-        logger.error('Response timed out after %d seconds.' % RESPONSE_TIMEOUT)
         return None
     else:
         logger.info(resp)
@@ -685,7 +674,6 @@ def query_nmea_versions(config_interface: DeviceInterface, args):
     config_interface.send_message('$PQTMVERNO,SUB')
     resp = config_interface.wait_for_message('$PQTMVERNO,SUB')
     if resp is None:
-        logger.error('Response timed out after %d seconds.' % RESPONSE_TIMEOUT)
         return None
     else:
         logger.info(resp)
@@ -698,9 +686,7 @@ def query_interfaces(config_interface: DeviceInterface, args):
     config_interface.send_message(MessageRequest(MessageType.SUPPORTED_IO_INTERFACES))
 
     resp = config_interface.wait_for_message(MessageType.SUPPORTED_IO_INTERFACES)
-    if resp is None:
-        logger.error('Response timed out after %d seconds.' % RESPONSE_TIMEOUT)
-    else:
+    if resp is not None:
         logger.info(str(resp))
     return resp
 
@@ -753,7 +739,6 @@ def request_reset(config_interface: DeviceInterface, args):
 
     resp = config_interface.wait_for_message(CommandResponseMessage.MESSAGE_TYPE)
     if not isinstance(resp, CommandResponseMessage):
-        logger.error('Response timed out after %d seconds.' % RESPONSE_TIMEOUT)
         return False
     elif resp.response != Response.OK:
         logger.error('Reset command rejected: %s (%d)' % (str(resp.response), int(resp.response)))
@@ -772,7 +757,6 @@ def request_shutdown(config_interface: DeviceInterface, args):
 
     resp = config_interface.wait_for_message(CommandResponseMessage.MESSAGE_TYPE)
     if not isinstance(resp, CommandResponseMessage):
-        logger.error('Response timed out after %d seconds.' % RESPONSE_TIMEOUT)
         return False
     elif resp.response != Response.OK:
         logger.error('Shutdown command rejected: %s (%d)' % (str(resp.response), int(resp.response)))
@@ -791,7 +775,6 @@ def request_startup(config_interface: DeviceInterface, args):
 
     resp = config_interface.wait_for_message(CommandResponseMessage.MESSAGE_TYPE)
     if not isinstance(resp, CommandResponseMessage):
-        logger.error('Response timed out after %d seconds.' % RESPONSE_TIMEOUT)
         return False
     elif resp.response != Response.OK:
         logger.error('Startup command rejected: %s (%d)' % (str(resp.response), int(resp.response)))
@@ -809,7 +792,6 @@ def request_export(config_interface: DeviceInterface, args):
     config_interface.send_message(MessageRequest(MessageType.VERSION_INFO))
     version_resp = config_interface.wait_for_message(VersionInfoMessage.MESSAGE_TYPE)
     if version_resp is None:
-        logger.error('Response timed out after %d seconds.' % RESPONSE_TIMEOUT)
         return None
     assert isinstance(version_resp, VersionInfoMessage)
 
@@ -961,7 +943,6 @@ def request_fault(config_interface: DeviceInterface, args):
     if expect_response:
         resp = config_interface.wait_for_message(CommandResponseMessage.MESSAGE_TYPE)
         if not isinstance(resp, CommandResponseMessage):
-            logger.error('Response timed out after %d seconds.' % RESPONSE_TIMEOUT)
             return False
         elif resp.response != Response.OK:
             logger.error('Fault command rejected: %s (%d)' % (str(resp.response), int(resp.response)))

--- a/bin/config_tool.py
+++ b/bin/config_tool.py
@@ -1577,7 +1577,7 @@ NMEA message types:
             baud_rate_parser.add_argument('baud_rate', type=int,
                                           help='The desired baud rate (in bits/second).')
 
-        if interface_id.type in (TransportType.UDP, TransportType.TCP, TransportType.CURRENT):
+        if interface_id.type in (TransportType.UDP, TransportType.TCP, TransportType.WEBSOCKET, TransportType.CURRENT):
             # config_tool.py apply INTERFACE_NAME port
             help = 'Configure the network port.'
             read_interface_config_type_parsers.add_parser(
@@ -1587,7 +1587,7 @@ NMEA message types:
             baud_rate_parser.add_argument('port', type=int,
                                           help='The desired network port.')
 
-        if interface_id.type in (TransportType.UDP, TransportType.UNIX, TransportType.CURRENT):
+        if interface_id.type in (TransportType.UDP, TransportType.TCP, TransportType.UNIX, TransportType.CURRENT):
             # config_tool.py apply INTERFACE_NAME remote_address
             help = 'Configure the remote hostname or IP address, or the socket file path for UNIX domain sockets.'
             read_interface_config_type_parsers.add_parser('remote_address', help=help, description=help)

--- a/p1_runner/device_interface.py
+++ b/p1_runner/device_interface.py
@@ -188,10 +188,15 @@ class DeviceInterface:
                 msgs = self.fe_decoder.on_data(b)
                 for msg in msgs:
                     if msg[0].message_type == msg_type:
-                        logger.debug('Response: %s', str(msg[1]))
-                        logger.debug(' '.join('%02x' % b for b in msg[2]))
-                        return msg[1]
+                        if isinstance(msg[1], MessagePayload):
+                            logger.debug('Response: %s', str(msg[1]))
+                            logger.debug(' '.join('%02x' % b for b in msg[2]))
+                            return msg[1]
+                        else:
+                            logger.error(f'Unexpected error decoding {msg_type} message.')
+                            return None
             elapsed = time.monotonic() - start_time
+        logger.error('Response timed out after %d seconds.' % response_timeout)
         return None
 
     def _wait_for_nmea_message(self, msg_type, response_timeout):
@@ -211,4 +216,5 @@ class DeviceInterface:
                         logger.debug('Response: %s', msg)
                         return msg
             elapsed = time.monotonic() - start_time
+        logger.error('Response timed out after %d seconds.' % response_timeout)
         return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ argparse-formatter>=1.4
 colorama>=0.4.4
 construct~=2.10.67
 deepdiff>=8.0.1
-fusion-engine-client==1.24.2rc1
+fusion-engine-client==1.24.2
 pynmea2~=1.18.0
 pyserial~=3.5
 urllib3>=1.21.1

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ requirements = [
     "colorama>=0.4.4",
     "construct~=2.10.67",
     "deepdiff>=8.0.1",
-    "fusion-engine-client==1.24.2rc1",
+    "fusion-engine-client==1.24.2",
     "psutil>=5.9.4",
     "pynmea2~=1.18.0",
     "pyserial~=3.5",


### PR DESCRIPTION
# New Features
- Added `config_tool` support for setting/getting transport direction (TCP) and socket type (UNIX socket)
- Added additional `config_tool` transport definitions for extended TCP, file, and websocket interfaces

# Fixes
- Fixed misleading "timed out" error on `config_tool` message decode failures
- Fixed `config_tool` hostname/port options for TCP and websocket interfaces